### PR TITLE
correct slug template name in sample schema

### DIFF
--- a/ckanext/fluent/fluent_scheming.json
+++ b/ckanext/fluent/fluent_scheming.json
@@ -16,7 +16,7 @@
     {
       "field_name": "name",
       "label": "URL",
-      "form_snippet": "dataset_slug.html",
+      "form_snippet": "slug.html",
       "validators": "not_empty unicode name_validator package_name_validator",
       "form_placeholder": "eg. yellow-submarine"
     },


### PR DESCRIPTION
dataset_slug.html does not exist, slug.html is the correct name to make sample schema work out of the box
