### PR TITLE
Allow json to store the non ascii text in the database

### DIFF
--- a/ckanext/fluent/validators.py
+++ b/ckanext/fluent/validators.py
@@ -124,7 +124,7 @@ def fluent_text(field, schema):
                 errors[key].append(_('Required language "%s" missing') % lang)
 
             if not errors[key]:
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             return
 
         # 3. separate fields
@@ -157,7 +157,7 @@ def fluent_text(field, schema):
 
         for lang in output:
             del extras[prefix + lang]
-        data[key] = json.dumps(output)
+        data[key] = json.dumps(output, ensure_ascii=False)
 
     return validator
 


### PR DESCRIPTION
I saw another json.dumps for tags, but since tags are not involved in the search, it should not be a problem, so there is no need to also pass the ensure_ascii option to json.dumps method

related issue https://github.com/ckan/ckanext-fluent/issues/47