### PR TITLE
compatibility with ckanext-scheming completeness branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,12 @@ jobs:
         run: pip install flake8 pycodestyle
       - name: Check syntax
         run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
-      # - name: Run flake8
-      #   run: flake8 . --count --max-line-length=127 --statistics --exclude ckan
 
   test:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.11", "2.10", 2.9]
+        ckan-version: ["2.11", "2.10"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install requirements

--- a/ckanext/fluent/helpers.py
+++ b/ckanext/fluent/helpers.py
@@ -1,6 +1,8 @@
 from ckan.lib.i18n import get_available_locales
 
-from ckanext.scheming.helpers import scheming_language_text
+from ckan.plugins.toolkit import (
+    h, chained_helper, get_action, ObjectNotFound, NotAuthorized
+)
 
 
 def fluent_form_languages(field=None, entity_type=None, object_type=None,
@@ -19,9 +21,7 @@ def fluent_form_languages(field=None, entity_type=None, object_type=None,
     if schema and 'form_languages' in schema:
         return schema['form_languages']
     if entity_type and object_type:
-        # late import for compatibility with older ckanext-scheming
-        from ckanext.scheming.helpers import scheming_get_schema
-        schema = scheming_get_schema(entity_type, object_type)
+        schema = h.scheming_get_schema(entity_type, object_type)
         if schema and 'form_languages' in schema:
             return schema['form_languages']
 
@@ -53,11 +53,52 @@ def fluent_form_label(field, lang):
     If the field has a fluent_form_label defined the label will
     be taken from there.  If a matching label can't be found
     this helper will return the language code in uppercase and
-    the standard label.
+    the standard label or field name.
     """
     form_label = field.get('fluent_form_label', {})
 
     if lang in form_label:
-        return scheming_language_text(form_label[lang])
+        return h.scheming_language_text(form_label[lang])
 
-    return lang.upper() + ' ' + scheming_language_text(field['label'])
+    return lang.upper() + ' ' + h.scheming_language_text(
+        field.get('label', field['field_name'])
+    )
+
+
+@chained_helper
+def scheming_missing_required_fields(
+        next_helper, pages, data=None, package_id=None):
+    """
+    """
+    if package_id:
+        try:
+            data = get_action('package_show')({}, {"id": package_id})
+        except (ObjectNotFound, NotAuthorized):
+            pass
+    if data is None:
+        data = {}
+    missing = next_helper(pages, data, package_id)
+    if not data.get('type'):
+        return missing
+
+    schema = h.scheming_get_dataset_schema(data['type'])
+    for page_missing, page in zip(missing, pages):
+        for f in page['fields']:
+            if (
+                f['field_name'] not in data
+                or f['field_name'] in page_missing
+                or 'validators' not in f
+                or not any(v.startswith('fluent_') for v in f['validators'].split())
+            ):
+                continue
+            required_langs = fluent_form_languages(f, schema=schema)
+            alternate_langs = fluent_alternate_languages(f, schema=schema)
+            value = data[f['field_name']]
+            for lang in required_langs:
+                if value.get(lang) or any(
+                    value.get(l) for l in alternate_langs.get(lang, [])
+                ):
+                    continue
+                page_missing.append(f['field_name'])
+                break
+    return missing

--- a/ckanext/fluent/helpers.py
+++ b/ckanext/fluent/helpers.py
@@ -89,6 +89,7 @@ def scheming_missing_required_fields(
                 or f['field_name'] in page_missing
                 or 'validators' not in f
                 or not any(v.startswith('fluent_') for v in f['validators'].split())
+                or not f.get('required')
             ):
                 continue
             required_langs = fluent_form_languages(f, schema=schema)

--- a/ckanext/fluent/plugins.py
+++ b/ckanext/fluent/plugins.py
@@ -20,6 +20,8 @@ class FluentPlugin(p.SingletonPlugin):
         template_helpers = {
             'fluent_form_languages': helpers.fluent_form_languages,
             'fluent_form_label': helpers.fluent_form_label,
+            'scheming_missing_required_fields':
+                helpers.scheming_missing_required_fields,
         }
         if 'truncate' not in h:
             from ckan.lib.helpers import truncate

--- a/ckanext/fluent/tests/test_helpers.py
+++ b/ckanext/fluent/tests/test_helpers.py
@@ -36,8 +36,8 @@ class TestFluentHelpers(object):
         assert res == {'en': ['en-GB']}
 
     def test_fluent_form_label_exists(self):
-        
         field = {
+            'field_name': 'fname',
             'fluent_form_label': {
                 'en': 'English label',
                 'fr': 'French label'
@@ -48,8 +48,8 @@ class TestFluentHelpers(object):
         assert res == 'English label'
 
     def test_fluent_form_label_not_exists(self):
-        
         field = {
+            'field_name': 'fname',
             'fluent_form_label': {
                 'en': 'English label',
                 'fr': 'French label'


### PR DESCRIPTION
- extend checks for incomplete required fluent fields
- skip enforcing required checks for draft datasets when `draft_fields_required: false` in schema